### PR TITLE
removed noinspection intellij-specific annotation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/ScoringAlgorithm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/ScoringAlgorithm.java
@@ -9,7 +9,6 @@ import com.qualcomm.robotcore.hardware.Servo;
 import org.firstinspires.ftc.teamcode.subsystems.hardware.Hardware;
 import org.firstinspires.ftc.teamcode.subsystems.hardware.HardwareElement;
 
-/** @noinspection ALL */
 @Autonomous(name = "Scoring Algorithm", group = "auton")
 public class ScoringAlgorithm extends OpMode {
     private Hardware robot;


### PR DESCRIPTION
removed noinspection annotation
     noinspection is an intelliJ-specific annotation that was causing an error when we tried to merge. 